### PR TITLE
Fixed to reject 070... numbers

### DIFF
--- a/src/Fastwebmedia/UKMobileValidator/UKMobileValidator.php
+++ b/src/Fastwebmedia/UKMobileValidator/UKMobileValidator.php
@@ -18,7 +18,7 @@ class UKMobileValidator
      */
     public static function validMobileNumber($value)
     {
-        return preg_match('/^(\+44|0044|44|0)7\d{9}$/', preg_replace('/\s+/', '', $value)) === 1;
+        return preg_match('/^(\+44|0044|44|0)7[1-9]\d{8}$/', preg_replace('/\s+/', '', $value)) === 1;
     }
 
     /**
@@ -39,7 +39,7 @@ class UKMobileValidator
      */
     public static function validMobileNumberInternational($value)
     {
-        return preg_match('/^\+447\d{9}$/', preg_replace('/\s+/', '', $value)) === 1;
+        return preg_match('/^\+447[1-9]\d{8}$/', preg_replace('/\s+/', '', $value)) === 1;
     }
     
     

--- a/tests/UKMobileValidationTest.php
+++ b/tests/UKMobileValidationTest.php
@@ -32,6 +32,24 @@ class UKMobileValidatorTest extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue($result);
 	}
 
+	public static function provider_for_it_rejects_an_invalid_mobile()
+	{
+		return array(
+			array('07056 294847'),      //070... is not a mobile number!
+			array('08456 294847'),
+		);
+	}
+
+	/**
+	 * @dataProvider provider_for_it_rejects_an_invalid_mobile
+	 * @test
+	 */
+	public function it_rejects_an_invalid_mobile($mobileNumber)
+	{
+		$result = UKMobileValidator::validMobileNumber($mobileNumber);
+		$this->assertFalse($result);
+	}
+
 	public static function provider_for_it_validates_a_mobile_with_invalid_params()
 	{
 		return array(
@@ -77,6 +95,7 @@ class UKMobileValidatorTest extends \PHPUnit_Framework_TestCase {
 			array('00447956 294847'),
 			array('+4407956 294 847'),
 			array('+4407956294847'),
+			array('+447056294847'),
 		);
 	}
 
@@ -86,7 +105,7 @@ class UKMobileValidatorTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function it_validates_a_fq_mobile_with_invalid_params($mobileNumber)
 	{
-		$result = $result = UKMobileValidator::validMobileNumberInternational($mobileNumber);
+		$result = UKMobileValidator::validMobileNumberInternational($mobileNumber);
 		$this->assertFalse($result);
 	}
 
@@ -96,7 +115,7 @@ class UKMobileValidatorTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function it_validates_a_mobile_with_invalid_params($mobileNumber)
 	{
-		$result = $result = UKMobileValidator::validMobileNumberInternational($mobileNumber);
+		$result = UKMobileValidator::validMobileNumberInternational($mobileNumber);
 		$this->assertFalse($result);
 	}
 	


### PR DESCRIPTION
Hi.

I've modified your library to reject UK numbers beginning with 070.

It is important to know that although UK mobiles do generally begin 07, the 070 range specifically is actually not for mobiles at all, but is an old premium-rate number range. There have been quite a few cases of fraud, eg where people used 070 numbers to make it look like they were calling from a mobile and getting people to call them back.